### PR TITLE
Kde

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,12 @@ CachyOS is Arch-based, so the two distro folders are intentionally near-identica
 │   ├── setup_yay.sh       — installer using yay
 │   ├── setup_paru.sh      — installer using paru
 │   ├── manual_setup.txt   — 33-section manual reference
-│   └── packages/{pacman,aur,gnome,uninstall}.txt
+│   └── packages/{pacman,aur,gnome,kde,uninstall}.txt
 ├── cachyOs/               — CachyOS setup kit (same structure)
 │   ├── setup_yay.sh
 │   ├── setup_paru.sh
 │   ├── manual_setup.txt   — 35-section manual reference, CachyOS-adapted
-│   └── packages/{pacman,aur,gnome,uninstall}.txt
+│   └── packages/{pacman,aur,gnome,kde,uninstall}.txt
 ├── config/                — shared drop-in config (.bashrc, starship, fastfetch)
 ├── toolv2/                — shared topic-grouped command references
 └── PACKAGE_DIFF.md        — arch vs cachyOs package differences + rationale
@@ -31,19 +31,19 @@ CachyOS is Arch-based, so the two distro folders are intentionally near-identica
 
 ```bash
 cd arch      # or: cd cachyOs
-bash setup_yay.sh    # then choose option 4 (dry run) to preview
+bash setup_yay.sh    # then choose option 6 (dry run) to preview
 bash setup_paru.sh
 
 chmod +x setup_yay.sh && ./setup_yay.sh
 ```
 
-The interactive menu offers: install pacman packages, install AUR packages, install GNOME packages, uninstall packages, dry run, exit. Both scripts read their package lists from the sibling `packages/` directory (`$SCRIPT_DIR/packages`), so they must be run from inside their own distro folder.
+The interactive menu offers: install pacman packages, install AUR packages, install GNOME packages, install KDE packages, uninstall packages, dry run, exit. Both scripts read their package lists from the sibling `packages/` directory (`$SCRIPT_DIR/packages`), so they must be run from inside their own distro folder.
 
 ## Architecture
 
-**Per-distro folders** — `arch/` and `cachyOs/` each hold two parallel scripts (`setup_yay.sh`, `setup_paru.sh`) that are functionally identical except for the AUR helper used (`yay` vs `paru`). Package lists (`packages/pacman.txt`, `packages/aur.txt`, `packages/gnome.txt`, `packages/uninstall.txt`) are plain text — one package per line, `#` comments and blank lines ignored — and are the primary thing to edit when adding/removing packages.
+**Per-distro folders** — `arch/` and `cachyOs/` each hold two parallel scripts (`setup_yay.sh`, `setup_paru.sh`) that are functionally identical except for the AUR helper used (`yay` vs `paru`). Package lists (`packages/pacman.txt`, `packages/aur.txt`, `packages/gnome.txt`, `packages/kde.txt`, `packages/uninstall.txt`) are plain text — one package per line, `#` comments and blank lines ignored — and are the primary thing to edit when adding/removing packages.
 
-**GNOME packages are split out** — packages genuinely tied to the GNOME *desktop* (the shell, `gdm`, extensions, `gnome-tweaks`, `extension-manager`, `gnome-boxes`) live in `packages/gnome.txt` (not in `pacman.txt`/`aur.txt`), installed via menu option 3. Because that list mixes official-repo and AUR packages, `install_gnome_packages` always uses the AUR helper (`yay`/`paru` handle both). Skip it on a non-GNOME desktop. Keep the scope tight: generic GTK4/libadwaita apps (e.g. `planify`, `parabolic`, `devtoolbox`) run on any desktop and belong in `aur.txt`, not here — only add a package to `gnome.txt` if it requires or only makes sense under the GNOME desktop.
+**Desktop packages are split out** — packages genuinely tied to a specific *desktop* live in their own list, not in `pacman.txt`/`aur.txt`. GNOME packages (the shell, `gdm`, extensions, `gnome-tweaks`, `extension-manager`, `gnome-boxes`) live in `packages/gnome.txt` (menu option 3); KDE Plasma packages (the desktop/shell, `kwin`, `sddm`, `systemsettings`, Plasma integration like `plasma-nm`/`bluedevil`/`powerdevil`, and KDE apps like `dolphin`/`konsole`/`kate`) live in `packages/kde.txt` (menu option 4). Each is installed by its own function (`install_gnome_packages`, `install_kde_packages`) which always uses the AUR helper (`yay`/`paru` handle both repo and AUR packages). Install only the list matching your desktop; skip the others. Keep the scope tight: generic GTK4/libadwaita or Qt apps that run on any desktop belong in `aur.txt`, not here — only add a package to `gnome.txt`/`kde.txt` if it requires or only makes sense under that desktop.
 
 **arch vs cachyOs differences** — keep the two folders structurally in sync; only the package lists and distro-specific manual steps should diverge. The CachyOS scripts differ from Arch in two ways: the header reads "CACHYOS LINUX SETUP KIT", and `install_yay`/`install_paru` try `pacman -S` first (both helpers ship in the CachyOS repo / come pre-installed) before falling back to an AUR build. The CachyOS manual reference swaps in `chwd` for GPU drivers, `cachyos-rate-mirrors` for mirror ranking, and the `linux-cachyos` kernel. Whenever you change a package in one distro, decide whether it should change in the other and update `PACKAGE_DIFF.md`.
 

--- a/PACKAGE_DIFF.md
+++ b/PACKAGE_DIFF.md
@@ -9,7 +9,7 @@ CachyOS is Arch-based, so the two kits share the vast majority of their packages
 3. It ships **`paru`/`yay` pre-installed** and provides them as plain repo packages.
 4. It defaults to the optimized **`linux-cachyos` kernel** and uses **`chwd`** for hardware/GPU driver detection.
 
-> Counts: Arch `pacman.txt` 185 / CachyOS 197 · Arch `aur.txt` 32 / CachyOS 28 · `gnome.txt` 9 / 9 · `kde.txt` 22 / 22 · `uninstall.txt` 14 / 15.
+> Counts: Arch `pacman.txt` 191 / CachyOS 200 · Arch `aur.txt` 32 / CachyOS 28 · `gnome.txt` 9 / 9 · `kde.txt` 37 / 37 · `uninstall.txt` 14 / 15.
 >
 > **Desktop splits (both distros):** the GNOME desktop/shell/apps were pulled out of `pacman.txt`/`aur.txt` into `gnome.txt` (menu option 3), and the KDE Plasma desktop/session/apps into `kde.txt` (menu option 4). Both splits are identical on Arch and CachyOS, so they do **not** contribute to the arch-vs-cachy differences below.
 
@@ -84,12 +84,18 @@ On CachyOS the GNOME edition already ships `gdm` + the GNOME shell, so `--needed
 
 ## 🐬 KDE list (`kde.txt`)
 
-Identical on both distros (22 packages), installed via menu option 4 with the AUR helper (the entries are all in the official repos, but `yay`/`paru` handle them fine). Kept to packages genuinely tied to the **KDE Plasma desktop** — not generic Qt apps:
+Identical on both distros (37 packages), installed via menu option 4 with the AUR helper (the entries are all in the official repos, but `yay`/`paru` handle them fine). Kept to packages genuinely tied to the **KDE Plasma desktop** — not generic Qt or CLI apps:
 
-- **Plasma desktop & shell:** `plasma-desktop`, `plasma-workspace`, `kwin`, `systemsettings`, `sddm`
-- **KDE apps:** `dolphin`, `konsole`, `kate`, `ark`, `gwenview`, `okular`, `spectacle`
-- **Plasma integration:** `plasma-nm` (network), `bluedevil` (Bluetooth), `powerdevil` (power)
+- **Plasma desktop & shell:** `plasma-desktop`, `plasma-workspace`, `kwin`, `systemsettings`, `sddm`, `kscreen` (display config), `polkit-kde-agent` (auth popups), `xdg-desktop-portal-kde` (screen share / portals), `kwallet-pam` (auto-unlock wallet at login)
+- **KDE apps:** `dolphin`, `konsole`, `kate`, `ark`, `gwenview`, `okular`, `spectacle`, `isoimagewriter`
+- **Dolphin / file integration:** `kio-admin`, `dolphin-plugins`, `ffmpegthumbs`
+- **Connectivity / disk / info:** `kdeconnect`, `partitionmanager`, `plasma-systemmonitor`, `kinfocenter`
+- **Plasma integration:** `plasma-nm` (network), `plasma-pa` (volume tray), `phonon-qt6-gstreamer` (media backend), `bluedevil` (Bluetooth), `powerdevil` + `power-profiles-daemon` (power profiles)
 - **Supporting services:** `networkmanager`, `pipewire`, `pipewire-pulse`, `wireplumber`, `bluez`, `bluez-utils`, `upower`
+
+Tuned for a **laptop**: `power-profiles-daemon` backs PowerDevil's Power Save / Balanced / Performance switch (see `toolv2/desktop/power_profiles.txt`), `kscreen` handles external-monitor hotplug, and brightness/lid/battery come from `powerdevil` + `upower`. Touchpad gestures and fractional scaling work out of the box on Plasma's default Wayland session (`kwin`).
+
+Generic system/CLI tools that pair with this desktop (`udisks2`, `exfatprogs`, `inxi`, `hwinfo`, `usbutils`, `pciutils` — plus the already-present `btop`, `fastfetch`, `ntfs-3g`, `smartmontools`) live in `pacman.txt`, not here, since they run on any desktop. `inxi`/`hwinfo`/`usbutils`/`pciutils` are the CLI backends `kinfocenter` reads for richer hardware detail.
 
 Install only the desktop list matching your environment — picking both GNOME and KDE pulls in two display managers (`gdm` + `sddm`); enable just one. Skip this list on a non-KDE desktop.
 

--- a/PACKAGE_DIFF.md
+++ b/PACKAGE_DIFF.md
@@ -9,9 +9,9 @@ CachyOS is Arch-based, so the two kits share the vast majority of their packages
 3. It ships **`paru`/`yay` pre-installed** and provides them as plain repo packages.
 4. It defaults to the optimized **`linux-cachyos` kernel** and uses **`chwd`** for hardware/GPU driver detection.
 
-> Counts: Arch `pacman.txt` 185 / CachyOS 197 · Arch `aur.txt` 32 / CachyOS 28 · `gnome.txt` 9 / 9 · `uninstall.txt` 14 / 15.
+> Counts: Arch `pacman.txt` 185 / CachyOS 197 · Arch `aur.txt` 32 / CachyOS 28 · `gnome.txt` 9 / 9 · `kde.txt` 22 / 22 · `uninstall.txt` 14 / 15.
 >
-> **GNOME split (both distros):** the GNOME desktop, shell extensions, and GNOME-native apps/tools were pulled out of `pacman.txt`/`aur.txt` into a separate `gnome.txt`, installed via menu option 3. This split is identical on Arch and CachyOS, so it does **not** contribute to the arch-vs-cachy differences below.
+> **Desktop splits (both distros):** the GNOME desktop/shell/apps were pulled out of `pacman.txt`/`aur.txt` into `gnome.txt` (menu option 3), and the KDE Plasma desktop/session/apps into `kde.txt` (menu option 4). Both splits are identical on Arch and CachyOS, so they do **not** contribute to the arch-vs-cachy differences below.
 
 ---
 
@@ -79,6 +79,19 @@ Identical on both distros (9 packages), installed via menu option 3 with the AUR
 On CachyOS the GNOME edition already ships `gdm` + the GNOME shell, so `--needed` makes re-running this list harmless. Skip it on a non-GNOME desktop.
 
 > Moved out to `aur.txt` as regular apps: `planify`, `parabolic`, `devtoolbox` (GTK4/libadwaita apps that run on any desktop), and `pencil` (Electron-based Pencil Project). They use GTK but aren't tied to the GNOME desktop.
+
+---
+
+## 🐬 KDE list (`kde.txt`)
+
+Identical on both distros (22 packages), installed via menu option 4 with the AUR helper (the entries are all in the official repos, but `yay`/`paru` handle them fine). Kept to packages genuinely tied to the **KDE Plasma desktop** — not generic Qt apps:
+
+- **Plasma desktop & shell:** `plasma-desktop`, `plasma-workspace`, `kwin`, `systemsettings`, `sddm`
+- **KDE apps:** `dolphin`, `konsole`, `kate`, `ark`, `gwenview`, `okular`, `spectacle`
+- **Plasma integration:** `plasma-nm` (network), `bluedevil` (Bluetooth), `powerdevil` (power)
+- **Supporting services:** `networkmanager`, `pipewire`, `pipewire-pulse`, `wireplumber`, `bluez`, `bluez-utils`, `upower`
+
+Install only the desktop list matching your environment — picking both GNOME and KDE pulls in two display managers (`gdm` + `sddm`); enable just one. Skip this list on a non-KDE desktop.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A personal collection of scripts and configuration files for a fast, consistent 
 │   └── starship.toml        — terminal prompt config
 ├── toolv2/                  — shared topic-grouped command references
 │   ├── apps/                — flathub, ollama, xampp, vscode extensions, ytDown
-│   ├── desktop/             — battery (CPU/thermal), ai_local, fastfetch, …
+│   ├── desktop/             — battery (CPU/thermal), power_profiles (KDE), ai_local, fastfetch, …
 │   ├── runtime/             — paru, bash, node, python, anaconda
 │   └── system/              — ethernet, fonts, gdm, grub
 └── PACKAGE_DIFF.md          — arch vs cachyOs package diff + rationale

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A personal collection of scripts and configuration files for a fast, consistent 
 - **🐧 Two Distros:** Separate `arch/` and `cachyOs/` kits with the same structure but distro-tuned package lists. See [`PACKAGE_DIFF.md`](PACKAGE_DIFF.md) for what differs and why.
 - **🔧 Editable Package Lists:** All packages live in plain text files under each distro's `packages/` folder — add or remove a package by editing a single line, no scripting needed.
 - **🐢 Optional GNOME Layer:** Packages tied to the GNOME desktop (shell, `gdm`, extensions, tweaks, `gnome-boxes`) are split into `packages/gnome.txt` and installed via a dedicated menu option — skip it entirely on a non-GNOME desktop. Generic GTK apps stay in `aur.txt`.
+- **🐬 Optional KDE Layer:** Packages tied to the KDE Plasma desktop (Plasma shell, `kwin`, `sddm`, `systemsettings`, integration like `plasma-nm`/`bluedevil`/`powerdevil`, and KDE apps like `dolphin`/`konsole`/`kate`) are split into `packages/kde.txt` and installed via their own menu option — skip it on a non-KDE desktop. Generic Qt apps stay in `aur.txt`.
 - **🎨 Post-Installation Configuration:** The shared `config/` directory holds drop-in configs for `fastfetch`, `starship`, and a working `.bashrc`.
 - **🗂️ Organized Guides:** The shared `toolv2/` directory groups command references by topic for faster lookup.
 - **📖 Manual Setup Guide:** Each distro folder ships a `manual_setup.txt` documenting every manual step, organized into numbered sections.
@@ -28,12 +29,13 @@ A personal collection of scripts and configuration files for a fast, consistent 
 │       ├── pacman.txt       — official repo packages
 │       ├── aur.txt          — AUR packages
 │       ├── gnome.txt        — GNOME desktop, extensions & GNOME apps
+│       ├── kde.txt          — KDE Plasma desktop, session & KDE apps
 │       └── uninstall.txt    — packages to remove (bloat / replaced apps)
 ├── cachyOs/                 — CachyOS setup kit (same layout)
 │   ├── setup_paru.sh
 │   ├── setup_yay.sh
 │   ├── manual_setup.txt     — CachyOS-adapted manual reference (35 sections)
-│   └── packages/{pacman,aur,gnome,uninstall}.txt
+│   └── packages/{pacman,aur,gnome,kde,uninstall}.txt
 ├── config/                  — shared drop-in configuration
 │   ├── .bashrc              — working bash config (starship, pyenv, nvm, flutter)
 │   ├── fastfetch/           — system-info display configs, presets, assets
@@ -73,6 +75,7 @@ Open any file under `packages/` and add or remove packages before running. Lines
 packages/pacman.txt    — official repo packages
 packages/aur.txt       — AUR packages
 packages/gnome.txt     — GNOME desktop / extensions / GNOME apps
+packages/kde.txt       — KDE Plasma desktop / session / KDE apps
 packages/uninstall.txt — packages to uninstall
 ```
 
@@ -94,9 +97,10 @@ On Arch the AUR helper is installed automatically if missing. On CachyOS both `p
 1) Install official (pacman) packages
 2) Install AUR packages
 3) Install GNOME packages (desktop, extensions, GNOME apps)
-4) Uninstall packages
-5) Dry run (preview)
-6) Exit
+4) Install KDE packages (Plasma desktop, session, KDE apps)
+5) Uninstall packages
+6) Dry run (preview)
+7) Exit
 ```
 
 ---
@@ -116,7 +120,7 @@ Every added/removed package and the reasoning is documented in [`PACKAGE_DIFF.md
 
 ## ⚠️ Important Notes
 
-- Always run **option 4 (dry run)** first to preview all changes before applying them.
+- Always run **option 6 (dry run)** first to preview all changes before applying them.
 - The scripts require `sudo` privileges.
 - Some packages need extra steps after install — check the distro's `manual_setup.txt` and the shared `toolv2/` references.
 - **CachyOS:** never add `cachyos-*` meta packages to `uninstall.txt` — removing them breaks the curated setup.

--- a/arch/packages/kde.txt
+++ b/arch/packages/kde.txt
@@ -1,6 +1,9 @@
 # KDE Plasma desktop environment, core session components, and KDE-native apps.
 # Installed via the AUR helper (yay/paru) since this list may mix repo and AUR
 # packages. Skip this list entirely if you run a non-KDE desktop.
+#
+# Scope: only packages genuinely tied to the KDE/Plasma desktop live here.
+# Generic CLI/system tools (btop, inxi, usbutils, ntfs-3g, …) live in pacman.txt.
 
 # ── Plasma Desktop & Shell ────────────────────────────────────────────────────
 plasma-desktop
@@ -8,6 +11,10 @@ plasma-workspace
 kwin
 systemsettings
 sddm
+kscreen                 # display config — external monitor / projector hotplug
+polkit-kde-agent        # authentication (password) popups for privileged actions
+xdg-desktop-portal-kde  # screenshots, screen sharing, sandboxed-app file dialogs
+kwallet-pam             # auto-unlock KWallet at login (stores WiFi/app secrets)
 
 # ── KDE Apps ──────────────────────────────────────────────────────────────────
 dolphin
@@ -17,6 +24,22 @@ ark
 gwenview
 okular
 spectacle
+isoimagewriter          # write ISO images to USB
+
+# ── Dolphin / File Integration ────────────────────────────────────────────────
+kio-admin               # open/edit files as root from Dolphin (admin:// protocol)
+dolphin-plugins         # git/svn/dropbox context-menu integration
+ffmpegthumbs            # video thumbnails in Dolphin
+
+# ── Connectivity ──────────────────────────────────────────────────────────────
+kdeconnect              # phone integration (notifications, file transfer, remote)
+
+# ── Disk & Storage ────────────────────────────────────────────────────────────
+partitionmanager        # KDE partition editor
+
+# ── System Info & Monitoring ──────────────────────────────────────────────────
+plasma-systemmonitor    # KDE resource/process monitor GUI
+kinfocenter             # hardware / system information center
 
 # ── Network ───────────────────────────────────────────────────────────────────
 networkmanager
@@ -26,6 +49,8 @@ plasma-nm
 pipewire
 pipewire-pulse
 wireplumber
+plasma-pa               # volume control applet in the system tray
+phonon-qt6-gstreamer    # Phonon backend — KDE system sounds & media playback
 
 # ── Bluetooth ─────────────────────────────────────────────────────────────────
 bluez
@@ -35,3 +60,4 @@ bluedevil
 # ── Power Management ──────────────────────────────────────────────────────────
 powerdevil
 upower
+power-profiles-daemon   # backend for PowerDevil's Power Save / Balanced / Performance switch

--- a/arch/packages/kde.txt
+++ b/arch/packages/kde.txt
@@ -1,0 +1,37 @@
+# KDE Plasma desktop environment, core session components, and KDE-native apps.
+# Installed via the AUR helper (yay/paru) since this list may mix repo and AUR
+# packages. Skip this list entirely if you run a non-KDE desktop.
+
+# ── Plasma Desktop & Shell ────────────────────────────────────────────────────
+plasma-desktop
+plasma-workspace
+kwin
+systemsettings
+sddm
+
+# ── KDE Apps ──────────────────────────────────────────────────────────────────
+dolphin
+konsole
+kate
+ark
+gwenview
+okular
+spectacle
+
+# ── Network ───────────────────────────────────────────────────────────────────
+networkmanager
+plasma-nm
+
+# ── Audio (PipeWire) ──────────────────────────────────────────────────────────
+pipewire
+pipewire-pulse
+wireplumber
+
+# ── Bluetooth ─────────────────────────────────────────────────────────────────
+bluez
+bluez-utils
+bluedevil
+
+# ── Power Management ──────────────────────────────────────────────────────────
+powerdevil
+upower

--- a/arch/packages/pacman.txt
+++ b/arch/packages/pacman.txt
@@ -142,12 +142,15 @@ cpufetch
 cups
 cups-pk-helper
 efibootmgr
+exfatprogs
 fastfetch
 figlet
 flatpak
 gufw
 guvcview
+hwinfo
 intel-ucode
+inxi
 linux-headers
 lm_sensors
 mesa
@@ -158,6 +161,7 @@ nvm
 os-prober
 p7zip
 7zip
+pciutils
 postgresql
 rp-pppoe
 rsync
@@ -166,9 +170,11 @@ smartmontools
 speedtest-cli
 tar
 touchegg
+udisks2
 ufw
 unrar
 unzip
+usbutils
 xorg-server
 xorg-xinit
 zip

--- a/arch/setup_paru.sh
+++ b/arch/setup_paru.sh
@@ -55,16 +55,18 @@ print_header() {
 main_menu() {
   print_header
 
-  local n_pacman n_aur n_gnome n_remove
+  local n_pacman n_aur n_gnome n_kde n_remove
   n_pacman=$(pkg_count "$PKG_DIR/pacman.txt")
   n_aur=$(pkg_count "$PKG_DIR/aur.txt")
   n_gnome=$(pkg_count "$PKG_DIR/gnome.txt")
+  n_kde=$(pkg_count "$PKG_DIR/kde.txt")
   n_remove=$(pkg_count "$PKG_DIR/uninstall.txt")
 
   echo -e "${BOLD}${WHITE}  Packages${R}"
   echo -e "  ${GRAY}pacman.txt${R}    ${CYAN}${n_pacman} packages${R}"
   echo -e "  ${GRAY}aur.txt${R}       ${CYAN}${n_aur} packages${R}"
   echo -e "  ${GRAY}gnome.txt${R}     ${CYAN}${n_gnome} packages${R}"
+  echo -e "  ${GRAY}kde.txt${R}       ${CYAN}${n_kde} packages${R}"
   echo -e "  ${GRAY}uninstall.txt${R} ${CYAN}${n_remove} packages${R}"
   echo
   divider
@@ -72,13 +74,14 @@ main_menu() {
   echo -e "  ${BOLD}${GREEN} 1${R}  ${WHITE}Install pacman packages${R}     ${DIM}${GRAY}[${n_pacman}]${R}"
   echo -e "  ${BOLD}${GREEN} 2${R}  ${WHITE}Install AUR packages${R}        ${DIM}${GRAY}[${n_aur}]${R}"
   echo -e "  ${BOLD}${GREEN} 3${R}  ${WHITE}Install GNOME packages${R}      ${DIM}${GRAY}[${n_gnome}]${R}"
-  echo -e "  ${BOLD}${YELLOW} 4${R}  ${WHITE}Uninstall packages${R}          ${DIM}${GRAY}[${n_remove}]${R}"
-  echo -e "  ${BOLD}${CYAN} 5${R}  ${WHITE}Dry run preview${R}"
-  echo -e "  ${BOLD}${RED} 6${R}  ${WHITE}Exit${R}"
+  echo -e "  ${BOLD}${GREEN} 4${R}  ${WHITE}Install KDE packages${R}        ${DIM}${GRAY}[${n_kde}]${R}"
+  echo -e "  ${BOLD}${YELLOW} 5${R}  ${WHITE}Uninstall packages${R}          ${DIM}${GRAY}[${n_remove}]${R}"
+  echo -e "  ${BOLD}${CYAN} 6${R}  ${WHITE}Dry run preview${R}"
+  echo -e "  ${BOLD}${RED} 7${R}  ${WHITE}Exit${R}"
   echo
   divider
   echo
-  echo -ne "  ${BOLD}Choose [1-6]:${R} "
+  echo -ne "  ${BOLD}Choose [1-7]:${R} "
   read -r choice
   echo
 
@@ -86,10 +89,11 @@ main_menu() {
     1) install_pacman_packages ;;
     2) install_paru; install_aur_packages ;;
     3) install_paru; install_gnome_packages ;;
-    4) install_paru; uninstall_packages ;;
-    5) show_dry_run ;;
-    6) echo -e "  ${CYAN}Goodbye!${R}\n"; exit 0 ;;
-    *) error "Invalid option — please choose 1 to 6." ;;
+    4) install_paru; install_kde_packages ;;
+    5) install_paru; uninstall_packages ;;
+    6) show_dry_run ;;
+    7) echo -e "  ${CYAN}Goodbye!${R}\n"; exit 0 ;;
+    *) error "Invalid option — please choose 1 to 7." ;;
   esac
 
   echo
@@ -159,6 +163,19 @@ install_gnome_packages() {
   log "GNOME packages installed successfully."
 }
 
+install_kde_packages() {
+  local -a pkgs
+  mapfile -t pkgs < <(load_packages "$PKG_DIR/kde.txt")
+  echo
+  echo -e "${BOLD}${BLUE}  ┌─ Installing KDE packages ───────────────────────┐${R}"
+  echo -e "${BOLD}${BLUE}  │${R}  ${CYAN}${#pkgs[@]} packages  ›  paru -S${R}                      ${BOLD}${BLUE}│${R}"
+  echo -e "${BOLD}${BLUE}  └─────────────────────────────────────────────────┘${R}"
+  echo
+  paru -S --needed --noconfirm "${pkgs[@]}"
+  echo
+  log "KDE packages installed successfully."
+}
+
 uninstall_packages() {
   local -a pkgs
   mapfile -t pkgs < <(load_packages "$PKG_DIR/uninstall.txt")
@@ -192,6 +209,11 @@ show_dry_run() {
   echo -e "  ${BOLD}${BLUE}GNOME packages${R}  ${GRAY}($(pkg_count "$PKG_DIR/gnome.txt"))${R}"
   divider
   load_packages "$PKG_DIR/gnome.txt" | pr -2 -t -w 80 | sed 's/^/  /'
+
+  echo
+  echo -e "  ${BOLD}${BLUE}KDE packages${R}  ${GRAY}($(pkg_count "$PKG_DIR/kde.txt"))${R}"
+  divider
+  load_packages "$PKG_DIR/kde.txt" | pr -2 -t -w 80 | sed 's/^/  /'
 
   echo
   echo -e "  ${BOLD}${YELLOW}Packages to uninstall${R}  ${GRAY}($(pkg_count "$PKG_DIR/uninstall.txt"))${R}"

--- a/arch/setup_yay.sh
+++ b/arch/setup_yay.sh
@@ -55,16 +55,18 @@ print_header() {
 main_menu() {
   print_header
 
-  local n_pacman n_aur n_gnome n_remove
+  local n_pacman n_aur n_gnome n_kde n_remove
   n_pacman=$(pkg_count "$PKG_DIR/pacman.txt")
   n_aur=$(pkg_count "$PKG_DIR/aur.txt")
   n_gnome=$(pkg_count "$PKG_DIR/gnome.txt")
+  n_kde=$(pkg_count "$PKG_DIR/kde.txt")
   n_remove=$(pkg_count "$PKG_DIR/uninstall.txt")
 
   echo -e "${BOLD}${WHITE}  Packages${R}"
   echo -e "  ${GRAY}pacman.txt${R}    ${CYAN}${n_pacman} packages${R}"
   echo -e "  ${GRAY}aur.txt${R}       ${CYAN}${n_aur} packages${R}"
   echo -e "  ${GRAY}gnome.txt${R}     ${CYAN}${n_gnome} packages${R}"
+  echo -e "  ${GRAY}kde.txt${R}       ${CYAN}${n_kde} packages${R}"
   echo -e "  ${GRAY}uninstall.txt${R} ${CYAN}${n_remove} packages${R}"
   echo
   divider
@@ -72,13 +74,14 @@ main_menu() {
   echo -e "  ${BOLD}${GREEN} 1${R}  ${WHITE}Install pacman packages${R}     ${DIM}${GRAY}[${n_pacman}]${R}"
   echo -e "  ${BOLD}${GREEN} 2${R}  ${WHITE}Install AUR packages${R}        ${DIM}${GRAY}[${n_aur}]${R}"
   echo -e "  ${BOLD}${GREEN} 3${R}  ${WHITE}Install GNOME packages${R}      ${DIM}${GRAY}[${n_gnome}]${R}"
-  echo -e "  ${BOLD}${YELLOW} 4${R}  ${WHITE}Uninstall packages${R}          ${DIM}${GRAY}[${n_remove}]${R}"
-  echo -e "  ${BOLD}${CYAN} 5${R}  ${WHITE}Dry run preview${R}"
-  echo -e "  ${BOLD}${RED} 6${R}  ${WHITE}Exit${R}"
+  echo -e "  ${BOLD}${GREEN} 4${R}  ${WHITE}Install KDE packages${R}        ${DIM}${GRAY}[${n_kde}]${R}"
+  echo -e "  ${BOLD}${YELLOW} 5${R}  ${WHITE}Uninstall packages${R}          ${DIM}${GRAY}[${n_remove}]${R}"
+  echo -e "  ${BOLD}${CYAN} 6${R}  ${WHITE}Dry run preview${R}"
+  echo -e "  ${BOLD}${RED} 7${R}  ${WHITE}Exit${R}"
   echo
   divider
   echo
-  echo -ne "  ${BOLD}Choose [1-6]:${R} "
+  echo -ne "  ${BOLD}Choose [1-7]:${R} "
   read -r choice
   echo
 
@@ -86,10 +89,11 @@ main_menu() {
     1) install_pacman_packages ;;
     2) install_yay; install_aur_packages ;;
     3) install_yay; install_gnome_packages ;;
-    4) install_yay; uninstall_packages ;;
-    5) show_dry_run ;;
-    6) echo -e "  ${CYAN}Goodbye!${R}\n"; exit 0 ;;
-    *) error "Invalid option — please choose 1 to 6." ;;
+    4) install_yay; install_kde_packages ;;
+    5) install_yay; uninstall_packages ;;
+    6) show_dry_run ;;
+    7) echo -e "  ${CYAN}Goodbye!${R}\n"; exit 0 ;;
+    *) error "Invalid option — please choose 1 to 7." ;;
   esac
 
   echo
@@ -159,6 +163,19 @@ install_gnome_packages() {
   log "GNOME packages installed successfully."
 }
 
+install_kde_packages() {
+  local -a pkgs
+  mapfile -t pkgs < <(load_packages "$PKG_DIR/kde.txt")
+  echo
+  echo -e "${BOLD}${BLUE}  ┌─ Installing KDE packages ───────────────────────┐${R}"
+  echo -e "${BOLD}${BLUE}  │${R}  ${CYAN}${#pkgs[@]} packages  ›  yay -S${R}                       ${BOLD}${BLUE}│${R}"
+  echo -e "${BOLD}${BLUE}  └─────────────────────────────────────────────────┘${R}"
+  echo
+  yay -S --needed --noconfirm "${pkgs[@]}"
+  echo
+  log "KDE packages installed successfully."
+}
+
 uninstall_packages() {
   local -a pkgs
   mapfile -t pkgs < <(load_packages "$PKG_DIR/uninstall.txt")
@@ -192,6 +209,11 @@ show_dry_run() {
   echo -e "  ${BOLD}${BLUE}GNOME packages${R}  ${GRAY}($(pkg_count "$PKG_DIR/gnome.txt"))${R}"
   divider
   load_packages "$PKG_DIR/gnome.txt" | pr -2 -t -w 80 | sed 's/^/  /'
+
+  echo
+  echo -e "  ${BOLD}${BLUE}KDE packages${R}  ${GRAY}($(pkg_count "$PKG_DIR/kde.txt"))${R}"
+  divider
+  load_packages "$PKG_DIR/kde.txt" | pr -2 -t -w 80 | sed 's/^/  /'
 
   echo
   echo -e "  ${BOLD}${YELLOW}Packages to uninstall${R}  ${GRAY}($(pkg_count "$PKG_DIR/uninstall.txt"))${R}"

--- a/cachyOs/packages/kde.txt
+++ b/cachyOs/packages/kde.txt
@@ -1,6 +1,9 @@
 # KDE Plasma desktop environment, core session components, and KDE-native apps.
 # Installed via the AUR helper (yay/paru) since this list may mix repo and AUR
 # packages. Skip this list entirely if you run a non-KDE desktop.
+#
+# Scope: only packages genuinely tied to the KDE/Plasma desktop live here.
+# Generic CLI/system tools (btop, inxi, usbutils, ntfs-3g, …) live in pacman.txt.
 
 # ── Plasma Desktop & Shell ────────────────────────────────────────────────────
 plasma-desktop
@@ -8,6 +11,10 @@ plasma-workspace
 kwin
 systemsettings
 sddm
+kscreen                 # display config — external monitor / projector hotplug
+polkit-kde-agent        # authentication (password) popups for privileged actions
+xdg-desktop-portal-kde  # screenshots, screen sharing, sandboxed-app file dialogs
+kwallet-pam             # auto-unlock KWallet at login (stores WiFi/app secrets)
 
 # ── KDE Apps ──────────────────────────────────────────────────────────────────
 dolphin
@@ -17,6 +24,22 @@ ark
 gwenview
 okular
 spectacle
+isoimagewriter          # write ISO images to USB
+
+# ── Dolphin / File Integration ────────────────────────────────────────────────
+kio-admin               # open/edit files as root from Dolphin (admin:// protocol)
+dolphin-plugins         # git/svn/dropbox context-menu integration
+ffmpegthumbs            # video thumbnails in Dolphin
+
+# ── Connectivity ──────────────────────────────────────────────────────────────
+kdeconnect              # phone integration (notifications, file transfer, remote)
+
+# ── Disk & Storage ────────────────────────────────────────────────────────────
+partitionmanager        # KDE partition editor
+
+# ── System Info & Monitoring ──────────────────────────────────────────────────
+plasma-systemmonitor    # KDE resource/process monitor GUI
+kinfocenter             # hardware / system information center
 
 # ── Network ───────────────────────────────────────────────────────────────────
 networkmanager
@@ -26,6 +49,8 @@ plasma-nm
 pipewire
 pipewire-pulse
 wireplumber
+plasma-pa               # volume control applet in the system tray
+phonon-qt6-gstreamer    # Phonon backend — KDE system sounds & media playback
 
 # ── Bluetooth ─────────────────────────────────────────────────────────────────
 bluez
@@ -35,3 +60,4 @@ bluedevil
 # ── Power Management ──────────────────────────────────────────────────────────
 powerdevil
 upower
+power-profiles-daemon   # backend for PowerDevil's Power Save / Balanced / Performance switch

--- a/cachyOs/packages/kde.txt
+++ b/cachyOs/packages/kde.txt
@@ -1,0 +1,37 @@
+# KDE Plasma desktop environment, core session components, and KDE-native apps.
+# Installed via the AUR helper (yay/paru) since this list may mix repo and AUR
+# packages. Skip this list entirely if you run a non-KDE desktop.
+
+# ── Plasma Desktop & Shell ────────────────────────────────────────────────────
+plasma-desktop
+plasma-workspace
+kwin
+systemsettings
+sddm
+
+# ── KDE Apps ──────────────────────────────────────────────────────────────────
+dolphin
+konsole
+kate
+ark
+gwenview
+okular
+spectacle
+
+# ── Network ───────────────────────────────────────────────────────────────────
+networkmanager
+plasma-nm
+
+# ── Audio (PipeWire) ──────────────────────────────────────────────────────────
+pipewire
+pipewire-pulse
+wireplumber
+
+# ── Bluetooth ─────────────────────────────────────────────────────────────────
+bluez
+bluez-utils
+bluedevil
+
+# ── Power Management ──────────────────────────────────────────────────────────
+powerdevil
+upower

--- a/cachyOs/packages/pacman.txt
+++ b/cachyOs/packages/pacman.txt
@@ -160,12 +160,15 @@ cpufetch
 cups
 cups-pk-helper
 efibootmgr
+exfatprogs
 fastfetch
 figlet
 flatpak
 gufw
 guvcview
+hwinfo
 intel-ucode
+inxi
 lm_sensors
 mesa
 mesa-utils
@@ -175,6 +178,7 @@ nvm
 os-prober
 p7zip
 7zip
+pciutils
 postgresql
 rp-pppoe
 rsync
@@ -183,9 +187,11 @@ smartmontools
 speedtest-cli
 tar
 touchegg
+udisks2
 ufw
 unrar
 unzip
+usbutils
 xorg-server
 xorg-xinit
 zip

--- a/cachyOs/setup_paru.sh
+++ b/cachyOs/setup_paru.sh
@@ -55,16 +55,18 @@ print_header() {
 main_menu() {
   print_header
 
-  local n_pacman n_aur n_gnome n_remove
+  local n_pacman n_aur n_gnome n_kde n_remove
   n_pacman=$(pkg_count "$PKG_DIR/pacman.txt")
   n_aur=$(pkg_count "$PKG_DIR/aur.txt")
   n_gnome=$(pkg_count "$PKG_DIR/gnome.txt")
+  n_kde=$(pkg_count "$PKG_DIR/kde.txt")
   n_remove=$(pkg_count "$PKG_DIR/uninstall.txt")
 
   echo -e "${BOLD}${WHITE}  Packages${R}"
   echo -e "  ${GRAY}pacman.txt${R}    ${CYAN}${n_pacman} packages${R}"
   echo -e "  ${GRAY}aur.txt${R}       ${CYAN}${n_aur} packages${R}"
   echo -e "  ${GRAY}gnome.txt${R}     ${CYAN}${n_gnome} packages${R}"
+  echo -e "  ${GRAY}kde.txt${R}       ${CYAN}${n_kde} packages${R}"
   echo -e "  ${GRAY}uninstall.txt${R} ${CYAN}${n_remove} packages${R}"
   echo
   divider
@@ -72,13 +74,14 @@ main_menu() {
   echo -e "  ${BOLD}${GREEN} 1${R}  ${WHITE}Install pacman packages${R}     ${DIM}${GRAY}[${n_pacman}]${R}"
   echo -e "  ${BOLD}${GREEN} 2${R}  ${WHITE}Install AUR packages${R}        ${DIM}${GRAY}[${n_aur}]${R}"
   echo -e "  ${BOLD}${GREEN} 3${R}  ${WHITE}Install GNOME packages${R}      ${DIM}${GRAY}[${n_gnome}]${R}"
-  echo -e "  ${BOLD}${YELLOW} 4${R}  ${WHITE}Uninstall packages${R}          ${DIM}${GRAY}[${n_remove}]${R}"
-  echo -e "  ${BOLD}${CYAN} 5${R}  ${WHITE}Dry run preview${R}"
-  echo -e "  ${BOLD}${RED} 6${R}  ${WHITE}Exit${R}"
+  echo -e "  ${BOLD}${GREEN} 4${R}  ${WHITE}Install KDE packages${R}        ${DIM}${GRAY}[${n_kde}]${R}"
+  echo -e "  ${BOLD}${YELLOW} 5${R}  ${WHITE}Uninstall packages${R}          ${DIM}${GRAY}[${n_remove}]${R}"
+  echo -e "  ${BOLD}${CYAN} 6${R}  ${WHITE}Dry run preview${R}"
+  echo -e "  ${BOLD}${RED} 7${R}  ${WHITE}Exit${R}"
   echo
   divider
   echo
-  echo -ne "  ${BOLD}Choose [1-6]:${R} "
+  echo -ne "  ${BOLD}Choose [1-7]:${R} "
   read -r choice
   echo
 
@@ -86,10 +89,11 @@ main_menu() {
     1) install_pacman_packages ;;
     2) install_paru; install_aur_packages ;;
     3) install_paru; install_gnome_packages ;;
-    4) install_paru; uninstall_packages ;;
-    5) show_dry_run ;;
-    6) echo -e "  ${CYAN}Goodbye!${R}\n"; exit 0 ;;
-    *) error "Invalid option — please choose 1 to 6." ;;
+    4) install_paru; install_kde_packages ;;
+    5) install_paru; uninstall_packages ;;
+    6) show_dry_run ;;
+    7) echo -e "  ${CYAN}Goodbye!${R}\n"; exit 0 ;;
+    *) error "Invalid option — please choose 1 to 7." ;;
   esac
 
   echo
@@ -167,6 +171,19 @@ install_gnome_packages() {
   log "GNOME packages installed successfully."
 }
 
+install_kde_packages() {
+  local -a pkgs
+  mapfile -t pkgs < <(load_packages "$PKG_DIR/kde.txt")
+  echo
+  echo -e "${BOLD}${BLUE}  ┌─ Installing KDE packages ───────────────────────┐${R}"
+  echo -e "${BOLD}${BLUE}  │${R}  ${CYAN}${#pkgs[@]} packages  ›  paru -S${R}                      ${BOLD}${BLUE}│${R}"
+  echo -e "${BOLD}${BLUE}  └─────────────────────────────────────────────────┘${R}"
+  echo
+  paru -S --needed --noconfirm "${pkgs[@]}"
+  echo
+  log "KDE packages installed successfully."
+}
+
 uninstall_packages() {
   local -a pkgs
   mapfile -t pkgs < <(load_packages "$PKG_DIR/uninstall.txt")
@@ -200,6 +217,11 @@ show_dry_run() {
   echo -e "  ${BOLD}${BLUE}GNOME packages${R}  ${GRAY}($(pkg_count "$PKG_DIR/gnome.txt"))${R}"
   divider
   load_packages "$PKG_DIR/gnome.txt" | pr -2 -t -w 80 | sed 's/^/  /'
+
+  echo
+  echo -e "  ${BOLD}${BLUE}KDE packages${R}  ${GRAY}($(pkg_count "$PKG_DIR/kde.txt"))${R}"
+  divider
+  load_packages "$PKG_DIR/kde.txt" | pr -2 -t -w 80 | sed 's/^/  /'
 
   echo
   echo -e "  ${BOLD}${YELLOW}Packages to uninstall${R}  ${GRAY}($(pkg_count "$PKG_DIR/uninstall.txt"))${R}"

--- a/cachyOs/setup_yay.sh
+++ b/cachyOs/setup_yay.sh
@@ -55,16 +55,18 @@ print_header() {
 main_menu() {
   print_header
 
-  local n_pacman n_aur n_gnome n_remove
+  local n_pacman n_aur n_gnome n_kde n_remove
   n_pacman=$(pkg_count "$PKG_DIR/pacman.txt")
   n_aur=$(pkg_count "$PKG_DIR/aur.txt")
   n_gnome=$(pkg_count "$PKG_DIR/gnome.txt")
+  n_kde=$(pkg_count "$PKG_DIR/kde.txt")
   n_remove=$(pkg_count "$PKG_DIR/uninstall.txt")
 
   echo -e "${BOLD}${WHITE}  Packages${R}"
   echo -e "  ${GRAY}pacman.txt${R}    ${CYAN}${n_pacman} packages${R}"
   echo -e "  ${GRAY}aur.txt${R}       ${CYAN}${n_aur} packages${R}"
   echo -e "  ${GRAY}gnome.txt${R}     ${CYAN}${n_gnome} packages${R}"
+  echo -e "  ${GRAY}kde.txt${R}       ${CYAN}${n_kde} packages${R}"
   echo -e "  ${GRAY}uninstall.txt${R} ${CYAN}${n_remove} packages${R}"
   echo
   divider
@@ -72,13 +74,14 @@ main_menu() {
   echo -e "  ${BOLD}${GREEN} 1${R}  ${WHITE}Install pacman packages${R}     ${DIM}${GRAY}[${n_pacman}]${R}"
   echo -e "  ${BOLD}${GREEN} 2${R}  ${WHITE}Install AUR packages${R}        ${DIM}${GRAY}[${n_aur}]${R}"
   echo -e "  ${BOLD}${GREEN} 3${R}  ${WHITE}Install GNOME packages${R}      ${DIM}${GRAY}[${n_gnome}]${R}"
-  echo -e "  ${BOLD}${YELLOW} 4${R}  ${WHITE}Uninstall packages${R}          ${DIM}${GRAY}[${n_remove}]${R}"
-  echo -e "  ${BOLD}${CYAN} 5${R}  ${WHITE}Dry run preview${R}"
-  echo -e "  ${BOLD}${RED} 6${R}  ${WHITE}Exit${R}"
+  echo -e "  ${BOLD}${GREEN} 4${R}  ${WHITE}Install KDE packages${R}        ${DIM}${GRAY}[${n_kde}]${R}"
+  echo -e "  ${BOLD}${YELLOW} 5${R}  ${WHITE}Uninstall packages${R}          ${DIM}${GRAY}[${n_remove}]${R}"
+  echo -e "  ${BOLD}${CYAN} 6${R}  ${WHITE}Dry run preview${R}"
+  echo -e "  ${BOLD}${RED} 7${R}  ${WHITE}Exit${R}"
   echo
   divider
   echo
-  echo -ne "  ${BOLD}Choose [1-6]:${R} "
+  echo -ne "  ${BOLD}Choose [1-7]:${R} "
   read -r choice
   echo
 
@@ -86,10 +89,11 @@ main_menu() {
     1) install_pacman_packages ;;
     2) install_yay; install_aur_packages ;;
     3) install_yay; install_gnome_packages ;;
-    4) install_yay; uninstall_packages ;;
-    5) show_dry_run ;;
-    6) echo -e "  ${CYAN}Goodbye!${R}\n"; exit 0 ;;
-    *) error "Invalid option — please choose 1 to 6." ;;
+    4) install_yay; install_kde_packages ;;
+    5) install_yay; uninstall_packages ;;
+    6) show_dry_run ;;
+    7) echo -e "  ${CYAN}Goodbye!${R}\n"; exit 0 ;;
+    *) error "Invalid option — please choose 1 to 7." ;;
   esac
 
   echo
@@ -168,6 +172,19 @@ install_gnome_packages() {
   log "GNOME packages installed successfully."
 }
 
+install_kde_packages() {
+  local -a pkgs
+  mapfile -t pkgs < <(load_packages "$PKG_DIR/kde.txt")
+  echo
+  echo -e "${BOLD}${BLUE}  ┌─ Installing KDE packages ───────────────────────┐${R}"
+  echo -e "${BOLD}${BLUE}  │${R}  ${CYAN}${#pkgs[@]} packages  ›  yay -S${R}                       ${BOLD}${BLUE}│${R}"
+  echo -e "${BOLD}${BLUE}  └─────────────────────────────────────────────────┘${R}"
+  echo
+  yay -S --needed --noconfirm "${pkgs[@]}"
+  echo
+  log "KDE packages installed successfully."
+}
+
 uninstall_packages() {
   local -a pkgs
   mapfile -t pkgs < <(load_packages "$PKG_DIR/uninstall.txt")
@@ -201,6 +218,11 @@ show_dry_run() {
   echo -e "  ${BOLD}${BLUE}GNOME packages${R}  ${GRAY}($(pkg_count "$PKG_DIR/gnome.txt"))${R}"
   divider
   load_packages "$PKG_DIR/gnome.txt" | pr -2 -t -w 80 | sed 's/^/  /'
+
+  echo
+  echo -e "  ${BOLD}${BLUE}KDE packages${R}  ${GRAY}($(pkg_count "$PKG_DIR/kde.txt"))${R}"
+  divider
+  load_packages "$PKG_DIR/kde.txt" | pr -2 -t -w 80 | sed 's/^/  /'
 
   echo
   echo -e "  ${BOLD}${YELLOW}Packages to uninstall${R}  ${GRAY}($(pkg_count "$PKG_DIR/uninstall.txt"))${R}"

--- a/toolv2/desktop/power_profiles.txt
+++ b/toolv2/desktop/power_profiles.txt
@@ -1,0 +1,79 @@
+# ============================================================
+# DESKTOP / Power Profiles — PowerDevil + power-profiles-daemon
+# ============================================================
+# Purpose: Manage laptop power on KDE Plasma. PowerDevil is the
+#          Plasma power module (battery, brightness, suspend,
+#          lid actions); power-profiles-daemon is the backend
+#          that provides the Power Save / Balanced / Performance
+#          switch in the battery tray menu.
+# Notes:   For CPU-governor / thermal tuning (cpupower, thermald,
+#          auto-cpufreq) see battery.txt. PPD and TLP conflict —
+#          run only one. PowerDevil integrates with PPD, not TLP.
+# ============================================================
+
+
+# ---- 1) Install ----
+sudo pacman -S powerdevil power-profiles-daemon upower
+# powerdevil               — Plasma power management module
+# power-profiles-daemon    — profile backend (Power Save/Balanced/Performance)
+# upower                   — battery / power-source status daemon
+
+
+# ---- 2) Enable the services ----
+sudo systemctl enable --now power-profiles-daemon.service
+sudo systemctl enable --now upower.service
+systemctl status power-profiles-daemon.service
+
+
+# ---- 3) power-profiles-daemon CLI (powerprofilesctl) ----
+powerprofilesctl                       # show active + available profiles
+powerprofilesctl list                  # list profiles with details
+powerprofilesctl get                   # print the active profile
+powerprofilesctl set power-saver       # switch: power-saver | balanced | performance
+powerprofilesctl set balanced
+powerprofilesctl set performance
+
+# Watch what is holding a profile (apps can request performance/power-saver):
+powerprofilesctl list-holds
+
+
+# ---- 4) PowerDevil — where to configure in Plasma ----
+# System Settings → Power Management
+#   - Energy Saving      : screen/dim/suspend timeouts (on battery vs AC)
+#   - Power Profiles     : default profile per power state
+#   - Advanced Settings  : critical battery action, lid-close behavior
+# Battery icon in the system tray exposes the live profile switch.
+
+# Inspect / nudge PowerDevil over D-Bus:
+qdbus6 org.kde.Solid.PowerManagement /org/kde/Solid/PowerManagement \
+  org.kde.Solid.PowerManagement.currentProfile
+qdbus6 org.freedesktop.PowerManagement.Inhibit   # see suspend inhibitors
+
+
+# ---- 5) upower — battery state from the CLI ----
+upower -e                              # list power devices (find the battery path)
+upower -i /org/freedesktop/UPower/devices/battery_BAT0   # detail: charge, health, rate
+upower -d                              # dump everything (all devices)
+# Battery health = energy-full / energy-full-design (capacity vs factory spec).
+
+
+# ---- 6) Brightness (PowerDevil handles keys; manual fallback) ----
+# Brightness keys are handled by PowerDevil automatically. Manual control:
+brightnessctl set 50%                  # needs: sudo pacman -S brightnessctl
+brightnessctl get
+brightnessctl set +10%
+brightnessctl set 10%-
+
+
+# ---- 7) Verify suspend / lid behavior ----
+# Lid + suspend are owned by systemd-logind, surfaced through PowerDevil.
+systemctl suspend                      # test suspend-to-RAM
+cat /sys/power/mem_sleep               # supported sleep states ([s2idle] / deep)
+journalctl -b -u power-profiles-daemon # debug profile-switch issues
+
+
+# ---- 8) Conflict check (PPD vs TLP) ----
+# If profiles do not switch, TLP may be installed and overriding PPD:
+systemctl status tlp.service
+# To use PPD instead: sudo systemctl disable --now tlp.service && \
+#   sudo systemctl enable --now power-profiles-daemon.service

--- a/toolv2/desktop/system_status.txt
+++ b/toolv2/desktop/system_status.txt
@@ -6,6 +6,16 @@
 # ============================================================
 
 
+# ---- KDE Plasma (post-install — run after installing the kde.txt list) ----
+sudo systemctl enable --now sddm.service               # display manager / login screen
+sudo systemctl enable --now NetworkManager.service     # network stack (plasma-nm tray applet)
+sudo systemctl enable --now power-profiles-daemon.service  # PowerDevil power-profile switch
+# Only ONE display manager may be enabled — if switching from GNOME, first:
+#   sudo systemctl disable --now gdm.service
+# upower + udisks2 are D-Bus/socket activated — no manual enable needed.
+# Bluetooth (bluedevil) uses the Bluetooth unit below.
+# Verify the session after reboot: echo $XDG_SESSION_TYPE   (expect: wayland)
+
 # ---- Bluetooth ----
 sudo systemctl enable --now bluetooth
 
@@ -47,3 +57,8 @@ sudo systemctl status mysqld
 # ---- CPU power / thermals ----
 sudo systemctl enable --now cpupower.service
 sudo systemctl enable --now thermald
+
+# ---- Laptop maintenance (SSD trim + disk health) ----
+sudo systemctl enable --now fstrim.timer        # weekly SSD TRIM
+sudo systemctl enable --now smartd.service       # background disk-health monitoring (smartmontools)
+systemctl list-timers fstrim.timer               # confirm the trim timer is scheduled


### PR DESCRIPTION
This pull request adds first-class support for KDE Plasma as an optional desktop environment in the Arch and CachyOS setup kits. It introduces a dedicated `kde.txt` package list, updates all documentation and scripts to handle KDE alongside GNOME, and ensures the KDE install process is parallel to the existing GNOME workflow. Additionally, some generic system tools were moved from desktop-specific lists to `pacman.txt` for clarity.

**KDE Plasma support:**

* Added `packages/kde.txt` in both `arch/` and `cachyOs/` folders, containing 37 KDE Plasma desktop and app packages, with clear scope and install instructions. [[1]](diffhunk://#diff-dba8521d4c2822f4b93bc7487c8c08dae337bfe5c9eb25e281bfdcef3550446aR1-R63) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L19-R24) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R45) [[4]](diffhunk://#diff-5c2e10807102830e69cd274d86005eba01e320c2b77597db6bb7aa065c5bba36R85-R103)
* Updated all documentation (`README.md`, `CLAUDE.md`, `PACKAGE_DIFF.md`) to describe the new KDE layer, its menu option, and its intended use. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R45) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R78) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R103) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L34-R46) [[6]](diffhunk://#diff-5c2e10807102830e69cd274d86005eba01e320c2b77597db6bb7aa065c5bba36L12-R14) [[7]](diffhunk://#diff-5c2e10807102830e69cd274d86005eba01e320c2b77597db6bb7aa065c5bba36R85-R103)

**Script and menu enhancements:**

* Modified `setup_paru.sh` to add an "Install KDE packages" menu option, display KDE package counts, and implement the `install_kde_packages` function using the AUR helper. The dry run preview now also includes KDE packages. [[1]](diffhunk://#diff-ff2f32df68b9f9831f1b689e4716b008df8c384b6ef4537cf9913b0d796c7334L58-R96) [[2]](diffhunk://#diff-ff2f32df68b9f9831f1b689e4716b008df8c384b6ef4537cf9913b0d796c7334R166-R178) [[3]](diffhunk://#diff-ff2f32df68b9f9831f1b689e4716b008df8c384b6ef4537cf9913b0d796c7334R213-R217)

**Generic package list improvements:**

* Moved generic CLI/system tools (`exfatprogs`, `hwinfo`, `inxi`, `pciutils`, `udisks2`, `usbutils`) into `pacman.txt` so they're available to all desktops and not just KDE. [[1]](diffhunk://#diff-d6533c34b3c1534ab41c31c0d7a69319a9cf5ab2348a7a27250bd796585c2f02R145-R153) [[2]](diffhunk://#diff-d6533c34b3c1534ab41c31c0d7a69319a9cf5ab2348a7a27250bd796585c2f02R164) [[3]](diffhunk://#diff-d6533c34b3c1534ab41c31c0d7a69319a9cf5ab2348a7a27250bd796585c2f02R173-R177)

**Documentation and usability:**

* Updated all install instructions, menu option numbers, and usage notes to reflect the new KDE option and the shifted dry run menu position. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R103) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R123) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L34-R46)

These changes make it easy to set up either GNOME or KDE (or neither) on Arch or CachyOS, with clear separation of desktop-specific and generic packages.